### PR TITLE
a11y: fix nav ARIA, focus styles, skip link, hamburger size, logo alt

### DIFF
--- a/src/components/header/header.astro
+++ b/src/components/header/header.astro
@@ -8,12 +8,12 @@ import "./header.css";
 
 <header>
   <div class='nav-container'>
-    <a href='/'><Image src={logo3} alt='A bird.' width='100' height='100' /></a>
+    <a href='/'><Image src={logo3} alt='Roast Dinners Around The World - go to homepage' width='100' height='100' /></a>
     <h1 class='sr-only'>Roast Dinners Around The World</h1>
     <div class='logo'>
       <a href='/'>Roast Dinners Around The World</a>
     </div>
-    <button id='nav-toggle' aria-label='Toggle Navigation Menu'
+    <button id='nav-toggle' aria-label='Toggle Navigation Menu' aria-expanded='false' aria-controls='nav-menu'
       ><span></span></button
     >
 
@@ -27,16 +27,32 @@ import "./header.css";
     </nav>
   </div>
   <script>
-    document
-      .getElementById("nav-toggle")
-      .addEventListener("click", function () {
-        this.classList.toggle("open");
-        const menu = document.getElementById("nav-menu");
-        if (menu.style.display === "block") {
-          menu.style.display = "none";
-        } else {
-          menu.style.display = "block";
-        }
+    const toggle = document.getElementById("nav-toggle");
+    const menu = document.getElementById("nav-menu");
+    const navLinks = menu.querySelectorAll("a");
+
+    function setMenuLinks(hidden) {
+      navLinks.forEach((link) => {
+        link.setAttribute("tabindex", hidden ? "-1" : "0");
       });
+    }
+
+    // On load, hide links from tab order (menu is closed on mobile)
+    if (window.innerWidth < 1200) {
+      setMenuLinks(true);
+    }
+
+    toggle.addEventListener("click", function () {
+      const isExpanded = this.getAttribute("aria-expanded") === "true";
+      this.setAttribute("aria-expanded", String(!isExpanded));
+      this.classList.toggle("open");
+      if (isExpanded) {
+        menu.style.display = "none";
+        setMenuLinks(true);
+      } else {
+        menu.style.display = "block";
+        setMenuLinks(false);
+      }
+    });
   </script>
 </header>

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -60,15 +60,24 @@ header {
 
 #nav-toggle {
   position: relative;
-  width: 30px;
-  height: 20px;
+  width: 44px;
+  height: 44px;
   background: none;
   border: none;
   cursor: pointer;
   margin-right: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   @media (min-width: 1200px) {
     display: none;
+  }
+
+  &:focus-visible {
+    outline: 3px solid white;
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 }
 
@@ -78,7 +87,7 @@ header {
   content: "";
   display: block;
   position: absolute;
-  width: 100%;
+  width: 30px;
   height: 4px;
   background-color: white;
   transition:
@@ -87,7 +96,7 @@ header {
 }
 
 #nav-toggle::before {
-  top: 0;
+  top: 12px;
 }
 
 #nav-toggle span {
@@ -96,7 +105,7 @@ header {
 }
 
 #nav-toggle::after {
-  bottom: 0;
+  bottom: 12px;
 }
 
 #nav-toggle.open::before {
@@ -165,6 +174,15 @@ header {
 
   @media (min-width: 1200px) {
     color: #603d34;
+  }
+}
+
+#nav-menu a:focus-visible {
+  outline: 3px solid #603d34;
+  outline-offset: 2px;
+
+  @media (min-width: 1200px) {
+    outline-color: white;
   }
 }
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -90,9 +90,10 @@ import { SEO } from "astro-seo";
     </script>
   </head>
   <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="page-container">
       <Header />
-      <main>
+      <main id="main-content">
         <slot />
       </main>
       <Footer />

--- a/src/layouts/layout.css
+++ b/src/layouts/layout.css
@@ -1,3 +1,19 @@
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 0;
+  background: #333;
+  color: white;
+  padding: 0.75rem 1.5rem;
+  z-index: 9999;
+  font-size: 1rem;
+  text-decoration: none;
+
+  &:focus {
+    top: 0;
+  }
+}
+
 body {
   font-family: "Roboto", sans-serif;
   margin: 0;


### PR DESCRIPTION
## Summary

- **`aria-expanded` / `aria-controls`** added to nav toggle button; JS updated to keep state in sync so screen readers announce open/closed
- **Mobile focus trap fixed** — nav links get `tabindex="-1"` when menu is hidden, restored when opened
- **Hamburger touch target** increased from 30×20px to 44×44px (WCAG 2.5.5); visual bars unchanged
- **Focus styles** added via `:focus-visible` on nav toggle and all nav links
- **Skip navigation link** added in `BaseLayout.astro`; `<main>` given `id="main-content"`
- **Logo alt text** changed from `'A bird.'` to descriptive text

## Test plan

- [ ] Tab through the page — skip link should appear on first Tab press and jump to main content
- [ ] On mobile (<1200px), open the nav menu with keyboard — toggle should show `aria-expanded="true"`, nav links should be focusable
- [ ] Close the nav menu — `aria-expanded="false"`, nav links should not be reachable via Tab
- [ ] On desktop (≥1200px), nav links should always be in the tab order
- [ ] Check hamburger button tap target feels comfortable on a mobile device
- [ ] Verify logo image alt text reads correctly in a screen reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)