### PR TITLE
chore: remove Lighthouse CI

### DIFF
--- a/.github/workflows/pull_request_audit.yml
+++ b/.github/workflows/pull_request_audit.yml
@@ -3,61 +3,6 @@ on:
   pull_request:
     branches: [main]
 jobs:
-  lighthouse:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set NODE_ENV to production
-        run: echo "NODE_ENV=production" >> $GITHUB_ENV
-      - name: Vercel Action
-        id: vercel_action
-        uses: amondnet/vercel-action@v25
-        with:
-          vercel-token: ${{ secrets.RDAW_VERCEL_TOKEN }}
-          github-token: ${{ secrets.RWAR_GITHUB_TOKEN }}
-          vercel-org-id: ${{ secrets.ORG_ID }}
-          vercel-project-id: ${{ secrets.RDAW_PROJECT_ID }}
-      - name: Audit URLs using Lighthouse
-        id: lighthouse_audit
-        uses: treosh/lighthouse-ci-action@v12
-        with:
-          urls: |
-            ${{ steps.vercel_action.outputs.preview-url }}
-          budgetPath: ".github/lighthouse/budget.json"
-          # configPath: ".github/lighthouse/lighthouse.config.js"
-          uploadArtifacts: true
-          runs: 3
-      - name: Format lighthouse score
-        id: format_lighthouse_score
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const result = ${{ steps.lighthouse_audit.outputs.manifest }}[0].summary
-            const formatResult = (res) => Math.round((res * 100))
-            Object.keys(result).forEach(key => result[key] = formatResult(result[key]))
-            const score = res => res >= 90 ? '🟢' : res >= 50 ? '🟠' : '🔴'
-            const comment = [
-                `⚡️ [Lighthouse report](${steps.vercel_action.outputs.preview-url}) for the changes in this PR:`, # Preview URL link
-                '| Category | Score |',
-                '| --- | --- |',
-                `| ${score(result.performance)} Performance | ${result.performance} |`,
-                `| ${score(result.accessibility)} Accessibility | ${result.accessibility} |`,
-                `| ${score(result['best-practices'])} Best practices | ${result['best-practices']} |`,
-                `| ${score(result.seo)} SEO | ${result.seo} |`,
-                `| ${score(result.pwa)} PWA | ${result.pwa} |`,
-                ' ',
-            ].join('\n')
-            core.setOutput("comment", comment);
-      - name: Add comment to PR
-        id: comment_to_pr
-        uses: marocchino/sticky-pull-request-comment@v3
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.issue.number }}
-          header: lighthouse
-          message: |
-            ${{ steps.format_lighthouse_score.outputs.comment }}
   axe:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary
- Removes the Lighthouse CI job from the pull request audit workflow
- The axe accessibility job remains unchanged

## Test plan
- [ ] Verify CI runs only the axe job on new PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)