### PR TITLE
feat: shareable filter links via URL query params

### DIFF
--- a/src/components/sortPosts.test.tsx
+++ b/src/components/sortPosts.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import SortPosts from "./sortPosts";
 
 const posts = [
@@ -45,43 +45,53 @@ const posts = [
   },
 ];
 
+// Reset URL and stub history.replaceState before every test to prevent contamination
+beforeEach(() => {
+  Object.defineProperty(window, "location", {
+    writable: true,
+    value: { search: "", pathname: "/league-of-roasts", href: "http://localhost/league-of-roasts" },
+  });
+  vi.spyOn(history, "replaceState").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// Each data row has one link; querying links gives ordered data rows
+const getLinks = () => screen.getAllByRole("link");
+
 describe("SortPosts filtering", () => {
   it("renders all posts by default sorted by rating ascending", () => {
     render(<SortPosts posts={posts} />);
-    const items = screen.getAllByRole("listitem");
-    expect(items).toHaveLength(3);
+    const links = getLinks();
+    expect(links).toHaveLength(3);
     // ascending rating: 6 (Lamb Paris), 8 (Beef London), 9 (Beef Edinburgh)
-    expect(within(items[0]).getByRole("link")).toHaveTextContent("Lamb Paris");
-    expect(within(items[1]).getByRole("link")).toHaveTextContent("Beef London");
-    expect(within(items[2]).getByRole("link")).toHaveTextContent(
-      "Beef Edinburgh"
-    );
+    expect(links[0]).toHaveTextContent("Lamb Paris");
+    expect(links[1]).toHaveTextContent("Beef London");
+    expect(links[2]).toHaveTextContent("Beef Edinburgh");
   });
 
   it("filters by meat type", async () => {
     render(<SortPosts posts={posts} />);
     await userEvent.selectOptions(
-      screen.getByRole("combobox", { name: /filter by meat/i }),
+      screen.getByRole("combobox", { name: /meat/i }),
       "Beef"
     );
-    const items = screen.getAllByRole("listitem");
-    expect(items).toHaveLength(2);
-    expect(
-      items.every((li) =>
-        within(li).getByRole("link").textContent?.includes("Beef")
-      )
-    ).toBe(true);
+    const links = getLinks();
+    expect(links).toHaveLength(2);
+    expect(links.every((a) => a.textContent?.includes("Beef"))).toBe(true);
   });
 
   it("filters by country", async () => {
     render(<SortPosts posts={posts} />);
     await userEvent.selectOptions(
-      screen.getByRole("combobox", { name: /filter by country/i }),
+      screen.getByRole("combobox", { name: /country/i }),
       "France"
     );
-    const items = screen.getAllByRole("listitem");
-    expect(items).toHaveLength(1);
-    expect(within(items[0]).getByRole("link")).toHaveTextContent("Lamb Paris");
+    const links = getLinks();
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveTextContent("Lamb Paris");
   });
 
   it("filters by minimum rating", async () => {
@@ -90,12 +100,11 @@ describe("SortPosts filtering", () => {
       screen.getByRole("spinbutton", { name: /minimum/i }),
       "8"
     );
-    const items = screen.getAllByRole("listitem");
-    expect(items).toHaveLength(2);
-    // rating >= 8: Beef London (8) and Beef Edinburgh (9)
-    const links = items.map((li) => within(li).getByRole("link").textContent);
-    expect(links).toContain("Beef London");
-    expect(links).toContain("Beef Edinburgh");
+    const links = getLinks();
+    expect(links).toHaveLength(2);
+    const texts = links.map((a) => a.textContent);
+    expect(texts).toContain("Beef London");
+    expect(texts).toContain("Beef Edinburgh");
   });
 
   it("filters by maximum converted price", async () => {
@@ -104,26 +113,25 @@ describe("SortPosts filtering", () => {
       screen.getByRole("spinbutton", { name: /maximum/i }),
       "15"
     );
-    const items = screen.getAllByRole("listitem");
-    expect(items).toHaveLength(2);
-    // convertedPrice <= 15: Beef London (10) and Beef Edinburgh (15)
-    const links = items.map((li) => within(li).getByRole("link").textContent);
-    expect(links).toContain("Beef London");
-    expect(links).toContain("Beef Edinburgh");
+    const links = getLinks();
+    expect(links).toHaveLength(2);
+    const texts = links.map((a) => a.textContent);
+    expect(texts).toContain("Beef London");
+    expect(texts).toContain("Beef Edinburgh");
   });
 
   it("clears all filters to restore full list", async () => {
     render(<SortPosts posts={posts} />);
     await userEvent.selectOptions(
-      screen.getByRole("combobox", { name: /filter by meat/i }),
+      screen.getByRole("combobox", { name: /meat/i }),
       "Beef"
     );
-    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    expect(getLinks()).toHaveLength(2);
 
     await userEvent.click(
       screen.getByRole("button", { name: /clear all filters/i })
     );
-    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    expect(getLinks()).toHaveLength(3);
   });
 });
 
@@ -131,14 +139,12 @@ describe("SortPosts sorting", () => {
   it("toggles sort order from ascending to descending", async () => {
     render(<SortPosts posts={posts} />);
     await userEvent.click(
-      screen.getByRole("button", { name: /sort descending/i })
+      screen.getByRole("button", { name: /descending/i })
     );
-    const items = screen.getAllByRole("listitem");
+    const links = getLinks();
     // descending rating: 9 (Beef Edinburgh), 8 (Beef London), 6 (Lamb Paris)
-    expect(within(items[0]).getByRole("link")).toHaveTextContent(
-      "Beef Edinburgh"
-    );
-    expect(within(items[2]).getByRole("link")).toHaveTextContent("Lamb Paris");
+    expect(links[0]).toHaveTextContent("Beef Edinburgh");
+    expect(links[2]).toHaveTextContent("Lamb Paris");
   });
 
   it("sorts by convertedPrice ascending", async () => {
@@ -147,12 +153,76 @@ describe("SortPosts sorting", () => {
       screen.getByRole("combobox", { name: /sort by/i }),
       "convertedPrice"
     );
-    const items = screen.getAllByRole("listitem");
+    const links = getLinks();
     // ascending convertedPrice: 10, 15, 22
-    expect(within(items[0]).getByRole("link")).toHaveTextContent("Beef London");
-    expect(within(items[1]).getByRole("link")).toHaveTextContent(
-      "Beef Edinburgh"
+    expect(links[0]).toHaveTextContent("Beef London");
+    expect(links[1]).toHaveTextContent("Beef Edinburgh");
+    expect(links[2]).toHaveTextContent("Lamb Paris");
+  });
+});
+
+describe("SortPosts URL params", () => {
+  it("seeds meat filter from URL param on mount", () => {
+    window.location.search = "?meat=Beef";
+    render(<SortPosts posts={posts} />);
+    const links = getLinks();
+    expect(links).toHaveLength(2);
+    expect(links.every((a) => a.textContent?.includes("Beef"))).toBe(true);
+  });
+
+  it("seeds country filter from URL param on mount", () => {
+    window.location.search = "?country=France";
+    render(<SortPosts posts={posts} />);
+    const links = getLinks();
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveTextContent("Lamb Paris");
+  });
+
+  it("seeds sort column and order from URL params on mount", () => {
+    window.location.search = "?sortColumn=convertedPrice&sortOrder=desc";
+    render(<SortPosts posts={posts} />);
+    const links = getLinks();
+    // descending convertedPrice: 22 (Lamb Paris), 15 (Beef Edinburgh), 10 (Beef London)
+    expect(links[0]).toHaveTextContent("Lamb Paris");
+    expect(links[2]).toHaveTextContent("Beef London");
+  });
+
+  it("updates URL when a filter changes", async () => {
+    render(<SortPosts posts={posts} />);
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: /meat/i }),
+      "Lamb"
     );
-    expect(within(items[2]).getByRole("link")).toHaveTextContent("Lamb Paris");
+    await waitFor(() => {
+      expect(history.replaceState).toHaveBeenCalledWith(
+        null,
+        "",
+        expect.stringContaining("meat=Lamb")
+      );
+    });
+  });
+
+  it("clears URL params when all filters are cleared", async () => {
+    window.location.search = "?meat=Beef";
+    render(<SortPosts posts={posts} />);
+    await userEvent.click(screen.getByRole("button", { name: /clear all filters/i }));
+    await waitFor(() => {
+      const lastCall = vi.mocked(history.replaceState).mock.calls.at(-1);
+      expect(lastCall?.[2]).toBe(window.location.pathname);
+    });
+  });
+
+  it("renders a copy link button", () => {
+    render(<SortPosts posts={posts} />);
+    expect(screen.getByRole("button", { name: /copy link/i })).toBeInTheDocument();
+  });
+
+  it("shows confirmation text after copy link is clicked", async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    render(<SortPosts posts={posts} />);
+    await userEvent.click(screen.getByRole("button", { name: /copy link/i }));
+    expect(screen.getByRole("button", { name: /link copied/i })).toBeInTheDocument();
   });
 });

--- a/src/components/sortPosts.tsx
+++ b/src/components/sortPosts.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 
 type Post = {
   slug: string;
@@ -24,20 +24,39 @@ const columnLabels: Record<keyof Post["customfields"], string> = {
   price: "Price",
 };
 
+const getParam = (key: string) => {
+  if (typeof window === "undefined") return "";
+  return new URLSearchParams(window.location.search).get(key) ?? "";
+};
+
 const SortPosts = ({ posts }: { posts: Post[] }) => {
-  const [sortOrder, setSortOrder] = useState("asc");
-  const [sortColumn, setSortColumn] =
-    useState<keyof Post["customfields"]>("rating");
-  const [meatFilter, setMeatFilter] = useState("");
-  const [countryFilter, setCountryFilter] = useState("");
-  const [scoreFilter, setScoreFilter] = useState("");
-  const [priceFilter, setPriceFilter] = useState("");
+  const [sortOrder, setSortOrder] = useState(() => getParam("sortOrder") || "asc");
+  const [sortColumn, setSortColumn] = useState<keyof Post["customfields"]>(
+    () => (getParam("sortColumn") as keyof Post["customfields"]) || "rating"
+  );
+  const [meatFilter, setMeatFilter] = useState(() => getParam("meat"));
+  const [countryFilter, setCountryFilter] = useState(() => getParam("country"));
+  const [scoreFilter, setScoreFilter] = useState(() => getParam("score"));
+  const [priceFilter, setPriceFilter] = useState(() => getParam("price"));
+  const [copySuccess, setCopySuccess] = useState(false);
 
   const [showYearVisited, setShowYearVisited] = useState(true);
   const [showCountry, setShowCountry] = useState(true);
   const [showMeat, setShowMeat] = useState(true);
   const [showPrice, setShowPrice] = useState(true);
   const [showConvertedPrice, setShowConvertedPrice] = useState(true);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (sortColumn !== "rating") params.set("sortColumn", sortColumn);
+    if (sortOrder !== "asc") params.set("sortOrder", sortOrder);
+    if (meatFilter) params.set("meat", meatFilter);
+    if (countryFilter) params.set("country", countryFilter);
+    if (scoreFilter) params.set("score", scoreFilter);
+    if (priceFilter) params.set("price", priceFilter);
+    const search = params.toString();
+    history.replaceState(null, "", search ? `?${search}` : window.location.pathname);
+  }, [sortColumn, sortOrder, meatFilter, countryFilter, scoreFilter, priceFilter]);
 
   const handleCheckboxChange =
     (setter: React.Dispatch<React.SetStateAction<boolean>>) => () => {
@@ -88,6 +107,12 @@ const SortPosts = ({ posts }: { posts: Post[] }) => {
     setCountryFilter("");
     setScoreFilter("");
     setPriceFilter("");
+  };
+
+  const copyLink = () => {
+    navigator.clipboard.writeText(window.location.href);
+    setCopySuccess(true);
+    setTimeout(() => setCopySuccess(false), 2000);
   };
 
   const uniqueMeats = useMemo(
@@ -213,6 +238,10 @@ const SortPosts = ({ posts }: { posts: Post[] }) => {
 
       <button className="clear-button" onClick={clearFilters}>
         Clear All Filters
+      </button>
+
+      <button className="copy-link-button" onClick={copyLink}>
+        {copySuccess ? "Link copied!" : "Copy link"}
       </button>
 
       <ol className="grid-container" role="table" aria-label="Roast dinner reviews">

--- a/src/pages/league-of-roasts.css
+++ b/src/pages/league-of-roasts.css
@@ -170,3 +170,8 @@ input {
 .clear-button {
   margin-left: 16px;
 }
+
+.copy-link-button {
+  margin-left: 8px;
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
## Summary

- Filter and sort state is encoded as URL query params (e.g. `?meat=Beef&sortColumn=rating&sortOrder=desc`) using `history.replaceState` on every change — no page reload, no router, no backend change
- On mount, `SortPosts` reads `window.location.search` via `URLSearchParams` and seeds its state initialisers from those params, so any shared link opens the exact same filtered view
- Adds a **Copy link** button that writes `window.location.href` to the clipboard and briefly shows "Link copied!" confirmation

Also fixes pre-existing test failures: `li[role=row]` elements inside `ol[role=table]` were not matched by `getAllByRole("listitem")`, and `history.replaceState` was contaminating URL state between tests.

Closes #109

## Test plan

- [ ] Open `/league-of-roasts`, apply filters/sort — URL updates in address bar
- [ ] Copy the URL, open in a new tab — same filtered view loads
- [ ] Click "Copy link" button — clipboard contains current URL, button briefly shows "Link copied!"
- [ ] Clear all filters — URL params removed from address bar
- [ ] All 15 unit tests pass (`npx vitest run src/components/sortPosts.test.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)