### PR TITLE
perf: parallelise independent fetches on league-of-roasts page

### DIFF
--- a/src/pages/league-of-roasts.astro
+++ b/src/pages/league-of-roasts.astro
@@ -61,18 +61,15 @@ const fetchPostsAndCurrency = async () => {
   }
 };
 
-const posts = await fetchPostsAndCurrency();
+const [posts, singlePostResult] = await Promise.all([
+  fetchPostsAndCurrency(),
+  fetchGraphQL(SINGLE_POST_QUERY, { id: PAGE_IDS.LEAGUE_OF_ROASTS }).catch((error) => {
+    console.error("Error fetching GraphQL data:", error);
+    throw error;
+  }),
+]);
 
-const variables = { id: PAGE_IDS.LEAGUE_OF_ROASTS };
-let singlePost: unknown;
-
-try {
-  const { page } = await fetchGraphQL(SINGLE_POST_QUERY, variables);
-  singlePost = page;
-} catch (error) {
-  console.error("Error fetching GraphQL data:", error);
-  throw error;
-}
+const singlePost = singlePostResult?.page;
 ---
 
 <BaseLayout


### PR DESCRIPTION
## Summary

- Wraps `fetchPostsAndCurrency()` and the `SINGLE_POST_QUERY` GraphQL fetch in `Promise.all` so they run concurrently instead of sequentially
- The single-post query latency now overlaps with the posts + currency waterfall, removing one serial round-trip from the render path
- Error handling preserved via a `.catch()` arm on the GraphQL fetch

Closes #125

## Test plan
- [ ] League of Roasts page renders correctly with featured image and sorted posts
- [ ] If the GraphQL fetch fails, error is still logged and thrown as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)