### PR TITLE
a11y: live region announcement when filter results change

### DIFF
--- a/src/components/sortPosts.test.tsx
+++ b/src/components/sortPosts.test.tsx
@@ -253,6 +253,8 @@ describe("SortPosts URL params", () => {
     });
     render(<SortPosts posts={posts} />);
     await userEvent.click(screen.getByRole("button", { name: /copy link/i }));
-    expect(screen.getByRole("status")).toHaveTextContent("Link copied!");
+    const statusRegions = screen.getAllByRole("status");
+    const copyStatus = statusRegions.find((el) => el.textContent === "Link copied!");
+    expect(copyStatus).toBeTruthy();
   });
 });

--- a/src/components/sortPosts.tsx
+++ b/src/components/sortPosts.tsx
@@ -238,6 +238,10 @@ const SortPosts = ({ posts }: { posts: Post[] }) => {
         {copySuccess ? "Link copied!" : ""}
       </div>
 
+      <div role="status" aria-live="polite" aria-atomic="true" className="visually-hidden">
+        {`Showing ${sortedPosts.length} of ${posts.length} results`}
+      </div>
+
       <table className="grid-container" aria-label="Roast dinner reviews">
         <thead>
           <tr className="grid-item grid-header">


### PR DESCRIPTION
## Summary

- Adds a `role="status" aria-live="polite" aria-atomic="true"` region below the filter controls in `sortPosts.tsx`
- Renders `"Showing X of Y results"` derived from `sortedPosts.length` vs `posts.length`, updating automatically whenever filters change
- Region is visually hidden but announced to screen readers, satisfying WCAG 2.1 criterion 4.1.3 Status Messages

Closes #131

## Test plan

- [ ] Apply a meat, country, score, or price filter and confirm a screen reader announces the result count
- [ ] Clear filters and confirm the count returns to the total
- [ ] Verify the visually-hidden region does not affect the visible layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)